### PR TITLE
Add support for HTTPS routing

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -18,6 +18,10 @@
 		{
 			"ImportPath": "github.com/flynn/rpcplus",
 			"Rev": "68355e62cadb10d431f81b507ee30805b99022cd"
-		}
+		},
+                {
+                        "ImportPath": "github.com/inconshreveable/go-vhost",
+                        "Rev": "abc5f6a77596abba0c71c07cfe22b6ccfd0a7d2d"
+                }
 	]
 }

--- a/examples/client/client.go
+++ b/examples/client/client.go
@@ -1,21 +1,114 @@
 package main
 
 import (
+	"bytes"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 
 	"github.com/flynn/rpcplus"
 	"github.com/flynn/strowger/types"
+	"strings"
 )
 
 func main() {
-	client, err := rpcplus.DialHTTP("tcp", "localhost:1115")
+	rpcAddr := flag.String("rpc", "localhost:1115", "strowger RPC address to connect to")
+	certPath := flag.String("cert", "", "path to DER encoded certificate for SSL, - for stdin")
+	keyPath := flag.String("key", "", "path to DER encoded private key for SSL, - for stdin")
+	flag.Parse()
+	if len(flag.Args()) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s [flags] domain service-name\n", os.Args[0])
+		flag.PrintDefaults()
+		os.Exit(64)
+	}
+
+	domain, serviceName := flag.Arg(0), flag.Arg(1)
+
+	var stdin []byte
+	var err error
+	if *certPath == "-" || *keyPath == "-" {
+		stdin, err = ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			log.Fatal("Failed to read from stdin: ", err)
+		}
+	}
+
+	tlsCert, err := readCert(*certPath, stdin)
+	if err != nil {
+		return
+	}
+	tlsKey, err := readKey(*keyPath, stdin)
+	if err != nil {
+		return
+	}
+
+	client, err := rpcplus.DialHTTP("tcp", *rpcAddr)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	err = client.Call("Router.AddFrontend", &strowger.Config{Service: "example-server", HTTPDomain: os.Args[1]}, &struct{}{})
+	frontendConfig := &strowger.Config{
+		Service:    serviceName,
+		HTTPDomain: domain,
+		HTTPSCert:  tlsCert,
+		HTTPSKey:   tlsKey,
+	}
+	err = client.Call("Router.AddFrontend", frontendConfig, &struct{}{})
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+func readCert(path string, stdin []byte) ([]byte, error) {
+	if path == "-" {
+		var buffer bytes.Buffer
+		var derBlock *pem.Block
+		for {
+			derBlock, stdin = pem.Decode(stdin)
+			if derBlock == nil {
+				break
+			}
+			if derBlock.Type == "CERTIFICATE" {
+				buffer.Write(pem.EncodeToMemory(derBlock))
+			}
+		}
+		if buffer.Len() > 0 {
+			return buffer.Bytes(), nil
+		}
+		log.Fatal("No certificate PEM blocks found in stdin")
+	}
+	return readFile(path)
+}
+
+func readKey(path string, stdin []byte) ([]byte, error) {
+	if path == "-" {
+		var derBlock *pem.Block
+		for {
+			derBlock, stdin = pem.Decode(stdin)
+			if derBlock == nil {
+				break
+			}
+			if strings.Contains(derBlock.Type, "PRIVATE KEY") {
+				return pem.EncodeToMemory(derBlock), nil
+			}
+		}
+		log.Fatal("No private key PEM blocks found in stdin")
+	}
+	return readFile(path)
+}
+
+func readFile(path string) ([]byte, error) {
+	if path == "" {
+		return nil, nil
+	}
+
+	contents, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Printf("Failed to open %s: %s", path, err)
+		return nil, err
+	}
+	return contents, nil
 }

--- a/rpc.go
+++ b/rpc.go
@@ -13,7 +13,7 @@ type Router struct {
 func (r *Router) AddFrontend(config *strowger.Config, res *struct{}) error {
 	switch config.Type {
 	case strowger.FrontendHTTP:
-		if err := r.s.AddHTTPDomain(config.HTTPDomain, config.Service, nil, nil); err != nil {
+		if err := r.s.AddHTTPDomain(config.HTTPDomain, config.Service, config.HTTPSCert, config.HTTPSKey); err != nil {
 			return err
 		}
 	default:

--- a/server.go
+++ b/server.go
@@ -18,6 +18,7 @@ type Server struct {
 
 func (s *Server) ListenAndServe(quit <-chan struct{}) {
 	go s.HTTPFrontend.serve()
+	go s.HTTPFrontend.serveTLS()
 	go s.HTTPFrontend.syncDatabase()
 	<-quit
 	// TODO: unregister from service discovery
@@ -27,6 +28,7 @@ func (s *Server) ListenAndServe(quit <-chan struct{}) {
 func main() {
 	rpcAddr := flag.String("rpcaddr", ":1115", "rpc listen address")
 	httpAddr := flag.String("httpaddr", ":8080", "http frontend listen address")
+	httpsAddr := flag.String("httpsaddr", ":4433", "https frontend listen address")
 	flag.Parse()
 
 	// Will use DISCOVERD environment variable
@@ -42,7 +44,7 @@ func main() {
 	}
 
 	var s Server
-	s.HTTPFrontend = NewHTTPFrontend(*httpAddr, etcd.NewClient(etcdAddr), d)
+	s.HTTPFrontend = NewHTTPFrontend(*httpAddr, *httpsAddr, etcd.NewClient(etcdAddr), d)
 	rpc.Register(&Router{s})
 	rpc.HandleHTTP()
 	go http.ListenAndServe(*rpcAddr, nil)


### PR DESCRIPTION
I'd like to make strowger support HTTPs proxying, in particular, using SNI for multi-host support.

This isn't done yet (cert configuration in etcd needs to be added), but it is the first go code I am touching, nor am I very familiar with flynn, so I'd love some feedback.

There are some other assorted changes in there (like returning error responses for 404, bad gateway etc). I'm not expecting this pull request to be merged as-is, but would appreciate notes as to what can be.

I've added a dependency to go-vhost for parsing the SNI host.
