### PR TITLE
Support changing a route configuration

### DIFF
--- a/api.go
+++ b/api.go
@@ -41,7 +41,7 @@ func createRoute(req *http.Request, route strowger.Route, router *Router, r rend
 		return
 	}
 
-	if err := l.AddRoute(&route); err != nil {
+	if err := l.SetRoute(&route); err != nil {
 		log.Println(err)
 		r.JSON(500, struct{}{})
 		return

--- a/api_test.go
+++ b/api_test.go
@@ -104,6 +104,19 @@ func (s *S) TestAPIAddHTTPRoute(c *C) {
 	c.Assert(err, Equals, client.ErrNotFound)
 }
 
+func (s *S) TestAPIUpdateHTTPRoute(c *C) {
+	srv := newTestAPIServer()
+	defer srv.Close()
+
+	r := (&strowger.HTTPRoute{Domain: "example.com", Service: "foo"}).ToRoute()
+	err := srv.CreateRoute(r)
+	c.Assert(err, IsNil)
+
+	r = (&strowger.HTTPRoute{Domain: "example.com", Service: "bar"}).ToRoute()
+	err = srv.CreateRoute(r)
+	c.Assert(err, IsNil)
+}
+
 func (s *S) TestAPIListRoutes(c *C) {
 	srv := newTestAPIServer()
 	defer srv.Close()

--- a/data_store.go
+++ b/data_store.go
@@ -11,14 +11,14 @@ import (
 )
 
 type EtcdClient interface {
-	Create(key string, value string, ttl uint64) (*etcd.Response, error)
+	Set(key string, value string, ttl uint64) (*etcd.Response, error)
 	Get(key string, sort, recursive bool) (*etcd.Response, error)
 	Delete(key string, recursive bool) (*etcd.Response, error)
 	Watch(prefix string, waitIndex uint64, recursive bool, receiver chan *etcd.Response, stop chan bool) (*etcd.Response, error)
 }
 
 type DataStore interface {
-	Add(route *strowger.Route) error
+	Set(route *strowger.Route) error
 	Get(id string) (*strowger.Route, error)
 	List() ([]*strowger.Route, error)
 	Remove(id string) error
@@ -32,7 +32,7 @@ type DataStoreReader interface {
 }
 
 type SyncHandler interface {
-	Add(route *strowger.Route) error
+	Set(route *strowger.Route) error
 	Remove(id string) error
 }
 
@@ -53,12 +53,12 @@ type etcdDataStore struct {
 var ErrExists = errors.New("strowger: route already exists")
 var ErrNotFound = errors.New("strowger: route not found")
 
-func (s *etcdDataStore) Add(r *strowger.Route) error {
+func (s *etcdDataStore) Set(r *strowger.Route) error {
 	data, err := json.Marshal(r)
 	if err != nil {
 		return err
 	}
-	_, err = s.etcd.Create(s.path(r.ID), string(data), 0)
+	_, err = s.etcd.Set(s.path(r.ID), string(data), 0)
 	if e, ok := err.(*etcd.EtcdError); ok && e.ErrorCode == 105 {
 		err = ErrExists
 	}
@@ -128,7 +128,7 @@ func (s *etcdDataStore) Sync(h SyncHandler, started chan<- error) {
 			started <- err
 			return
 		}
-		if err := h.Add(route); err != nil {
+		if err := h.Set(route); err != nil {
 			started <- err
 			return
 		}
@@ -148,7 +148,7 @@ watch:
 			if err = json.Unmarshal([]byte(res.Node.Value), route); err != nil {
 				goto fail
 			}
-			err = h.Add(route)
+			err = h.Set(route)
 		}
 	fail:
 		if err != nil {

--- a/http.go
+++ b/http.go
@@ -106,14 +106,14 @@ func (s *HTTPListener) Start() error {
 
 var ErrClosed = errors.New("strowger: listener has been closed")
 
-func (s *HTTPListener) AddRoute(r *strowger.Route) error {
+func (s *HTTPListener) SetRoute(r *strowger.Route) error {
 	s.mtx.RLock()
 	defer s.mtx.RUnlock()
 	if s.closed {
 		return ErrClosed
 	}
 	r.ID = md5sum(r.HTTPRoute().Domain)
-	return s.ds.Add(r)
+	return s.ds.Set(r)
 }
 
 func md5sum(data string) string {
@@ -134,7 +134,7 @@ type httpSyncHandler struct {
 	l *HTTPListener
 }
 
-func (h *httpSyncHandler) Add(data *strowger.Route) error {
+func (h *httpSyncHandler) Set(data *strowger.Route) error {
 	route := data.HTTPRoute()
 	r := &httpRoute{
 		Domain:  route.Domain,
@@ -158,11 +158,16 @@ func (h *httpSyncHandler) Add(data *strowger.Route) error {
 	if h.l.closed {
 		return nil
 	}
-	if _, ok := h.l.routes[data.ID]; ok {
-		return ErrExists
-	}
 
 	service := h.l.services[r.Service]
+	if service != nil && service.name != r.Service {
+		service.refs--
+		if service.refs <= 0 {
+			service.ss.Close()
+			delete(h.l.services, service.name)
+		}
+		service = nil
+	}
 	if service == nil {
 		ss, err := h.l.discoverd.NewServiceSet(r.Service)
 		if err != nil {
@@ -176,7 +181,7 @@ func (h *httpSyncHandler) Add(data *strowger.Route) error {
 	h.l.routes[data.ID] = r
 	h.l.domains[r.Domain] = r
 
-	go h.l.wm.Send(&strowger.Event{Event: "add", ID: r.Domain})
+	go h.l.wm.Send(&strowger.Event{Event: "set", ID: r.Domain})
 	return nil
 }
 

--- a/http_test.go
+++ b/http_test.go
@@ -138,14 +138,14 @@ func assertGet(c *C, url, host, expected string) {
 }
 
 func addHTTPRoute(c *C, l *HTTPListener) *strowger.Route {
-	wait := waitForEvent(c, l, "add", "")
+	wait := waitForEvent(c, l, "set", "")
 	r := (&strowger.HTTPRoute{
 		Domain:  "example.com",
 		Service: "test",
 		TLSCert: string(localhostCert),
 		TLSKey:  string(localhostKey),
 	}).ToRoute()
-	err := l.AddRoute(r)
+	err := l.SetRoute(r)
 	c.Assert(err, IsNil)
 	wait()
 	return r

--- a/server.go
+++ b/server.go
@@ -16,7 +16,7 @@ import (
 type Listener interface {
 	Start() error
 	Close() error
-	AddRoute(*strowger.Route) error
+	SetRoute(*strowger.Route) error
 	RemoveRoute(id string) error
 	Watcher
 	DataStoreReader

--- a/setup_test.go
+++ b/setup_test.go
@@ -92,16 +92,13 @@ func (e *fakeEtcd) Watch(prefix string, waitIndex uint64, recursive bool, receiv
 	return &etcd.Response{Action: "watch"}, nil
 }
 
-func (e *fakeEtcd) Create(key string, value string, ttl uint64) (*etcd.Response, error) {
+func (e *fakeEtcd) Set(key string, value string, ttl uint64) (*etcd.Response, error) {
 	if key == "" || key[0] != '/' {
 		return nil, errors.New("etcd: key must start with /")
 	}
 	key = strings.TrimSuffix(key, "/")
 	e.mtx.Lock()
 	defer e.mtx.Unlock()
-	if _, ok := e.index[key]; ok {
-		return nil, &etcd.EtcdError{ErrorCode: 105, Message: "Key already exists"}
-	}
 
 	components := strings.Split(key, "/")[1:]
 	components[0] = "/" + components[0]

--- a/tcp_test.go
+++ b/tcp_test.go
@@ -100,12 +100,12 @@ func (s *S) TestAddTCPRoute(c *C) {
 }
 
 func addTCPRoute(c *C, l *TCPListener, port int) *strowger.TCPRoute {
-	wait := waitForEvent(c, l, "add", "")
+	wait := waitForEvent(c, l, "set", "")
 	r := (&strowger.TCPRoute{
 		Service: "test",
 		Port:    port,
 	}).ToRoute()
-	err := l.AddRoute(r)
+	err := l.SetRoute(r)
 	c.Assert(err, IsNil)
 	wait()
 	return r.TCPRoute()
@@ -152,7 +152,7 @@ func (s *S) TestTCPPortAllocation(c *C) {
 			discoverd.UnregisterAll()
 		}
 		r := (&strowger.TCPRoute{Service: "test"}).ToRoute()
-		err := l.AddRoute(r)
+		err := l.SetRoute(r)
 		c.Assert(err, Equals, ErrNoPorts)
 		for _, port := range ports {
 			wait := waitForEvent(c, l, "remove", port)


### PR DESCRIPTION
Currently, to change a route, you have to a) get a list of all routes, see if your's exists b) delete it c) then re-create it. This is painful, and causes unnecessary downtime, small as it may be.

A separate Update() api call could be added, but I would instead propose to replace Add() with Set(), as I see no value in a "domain already exists" error.
