### PR TITLE
Add a Set() operation to the front API.

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -104,6 +104,19 @@ func (s *S) TestAPIAddHTTPRoute(c *C) {
 	c.Assert(err, Equals, client.ErrNotFound)
 }
 
+func (s *S) TestAPISetHTTPRoute(c *C) {
+	srv := newTestAPIServer()
+	defer srv.Close()
+
+	r := (&strowger.HTTPRoute{Domain: "example.com", Service: "foo"}).ToRoute()
+	err := srv.SetRoute(r)
+	c.Assert(err, IsNil)
+
+	r = (&strowger.HTTPRoute{Domain: "example.com", Service: "bar"}).ToRoute()
+	err = srv.SetRoute(r)
+	c.Assert(err, IsNil)
+}
+
 func (s *S) TestAPIListRoutes(c *C) {
 	srv := newTestAPIServer()
 	defer srv.Close()

--- a/http_test.go
+++ b/http_test.go
@@ -138,7 +138,7 @@ func assertGet(c *C, url, host, expected string) {
 }
 
 func addHTTPRoute(c *C, l *HTTPListener) *strowger.Route {
-	wait := waitForEvent(c, l, "add", "")
+	wait := waitForEvent(c, l, "set", "")
 	r := (&strowger.HTTPRoute{
 		Domain:  "example.com",
 		Service: "test",

--- a/server.go
+++ b/server.go
@@ -17,6 +17,7 @@ type Listener interface {
 	Start() error
 	Close() error
 	AddRoute(*strowger.Route) error
+	SetRoute(*strowger.Route) error
 	RemoveRoute(id string) error
 	Watcher
 	DataStoreReader

--- a/setup_test.go
+++ b/setup_test.go
@@ -92,14 +92,22 @@ func (e *fakeEtcd) Watch(prefix string, waitIndex uint64, recursive bool, receiv
 	return &etcd.Response{Action: "watch"}, nil
 }
 
+func (e *fakeEtcd) Set(key string, value string, ttl uint64) (*etcd.Response, error) {
+	return e.set(key, value, ttl, true)
+}
+
 func (e *fakeEtcd) Create(key string, value string, ttl uint64) (*etcd.Response, error) {
+	return e.set(key, value, ttl, false)
+}
+
+func (e *fakeEtcd) set(key string, value string, ttl uint64, allowExist bool) (*etcd.Response, error) {
 	if key == "" || key[0] != '/' {
 		return nil, errors.New("etcd: key must start with /")
 	}
 	key = strings.TrimSuffix(key, "/")
 	e.mtx.Lock()
 	defer e.mtx.Unlock()
-	if _, ok := e.index[key]; ok {
+	if _, ok := e.index[key]; ok && !allowExist {
 		return nil, &etcd.EtcdError{ErrorCode: 105, Message: "Key already exists"}
 	}
 

--- a/tcp.go
+++ b/tcp.go
@@ -64,6 +64,20 @@ func (l *TCPListener) AddRoute(route *strowger.Route) error {
 	return l.ds.Add(route)
 }
 
+func (l *TCPListener) SetRoute(route *strowger.Route) error {
+	r := route.TCPRoute()
+	l.mtx.RLock()
+	defer l.mtx.RUnlock()
+	if l.closed {
+		return ErrClosed
+	}
+	if r.Port == 0 {
+		return errors.New("strowger: a port number needs to be specified")
+	}
+	route.ID = md5sum(strconv.Itoa(r.Port))
+	return l.ds.Set(route)
+}
+
 var ErrNoPorts = errors.New("strowger: no ports available")
 
 func (l *TCPListener) addWithAllocatedPort(route *strowger.Route) error {
@@ -126,7 +140,7 @@ type tcpSyncHandler struct {
 	l *TCPListener
 }
 
-func (h *tcpSyncHandler) Add(data *strowger.Route) error {
+func (h *tcpSyncHandler) Set(data *strowger.Route) error {
 	r := data.TCPRoute()
 
 	h.l.mtx.Lock()
@@ -165,7 +179,7 @@ func (h *tcpSyncHandler) Add(data *strowger.Route) error {
 	}
 	h.l.services[r.Port] = s
 	h.l.serviceIDs[data.ID] = s
-	go h.l.wm.Send(&strowger.Event{Event: "add", ID: data.ID})
+	go h.l.wm.Send(&strowger.Event{Event: "set", ID: data.ID})
 	return nil
 }
 

--- a/tcp_test.go
+++ b/tcp_test.go
@@ -100,7 +100,7 @@ func (s *S) TestAddTCPRoute(c *C) {
 }
 
 func addTCPRoute(c *C, l *TCPListener, port int) *strowger.TCPRoute {
-	wait := waitForEvent(c, l, "add", "")
+	wait := waitForEvent(c, l, "set", "")
 	r := (&strowger.TCPRoute{
 		Service: "test",
 		Port:    port,


### PR DESCRIPTION
As an alternative to #23.

This keeps the Add() call in the frontend API (the thing that writes to etcd), and adds a Set() call as an alternative.

In the backend (the thing that watches for etcd changes), I've changed it to do operate in set() mode only. If I change a key behind strowger's back in etcd directly, there is no reason it shouldn't simply accept that change.
